### PR TITLE
add a utility devShell output with dependencies for CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,5 +21,9 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com:${{ secrets.NIX_GITHUB_TOKEN }}
-      - name: build all flake templates
-        run: ./checks
+      - name: validate root devShell
+        run: nix develop -c echo "PASSED"
+      - name: validate formatting of all files
+        run: nix develop -c treefmt --fail-on-change
+      - name: build all flake templates on macOS and linux
+        run: nix develop -c checks

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,145 @@
+{
+  "nodes": {
+    "devshell": {
+      "locked": {
+        "lastModified": 1618523768,
+        "narHash": "sha256-Gev9da35pHUey3kGz/zrJFc/9ICs++vPCho7qB1mqd8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "709fe4d04a9101c9d224ad83f73416dce71baf21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_2": {
+      "locked": {
+        "lastModified": 1613310953,
+        "narHash": "sha256-GhAwxJ0Jfsj8LIQmEQylpVkcThUJgPChjo48DZeBQZA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f64db97388dda7c2c6f8fb7aa5d6d08365fb1e01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1612192764,
+        "narHash": "sha256-7EnLtZQWP6511G1ZPA7FmJlqAr3hWsAYb24tvTvJ/ec=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "6e149bfd726a8ebefa415f2d713ba6d942435abd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1619446560,
+        "narHash": "sha256-R9iG5d1ORvho5UlyEUsX8Nu1cnCV+YtWEHlWlqftaQo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "32f7980afb5e33f1e078a51e715b9f102f396a69",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1613418107,
+        "narHash": "sha256-UVG9gUzg9vZfmyLvz9pNUk1qxUWxHCZJWUULjlgxFTk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "69d5df6303374e52f56eb57fa0ed38793ed03718",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "treefmt": "treefmt"
+      }
+    },
+    "treefmt": {
+      "inputs": {
+        "devshell": "devshell_2",
+        "flake-utils": "flake-utils_2",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1619266404,
+        "narHash": "sha256-WrNkMk1HUO247JECxREyLapwHe/6T4BDjFzdi+eMnig=",
+        "owner": "numtide",
+        "repo": "treefmt",
+        "rev": "797b80e98dae6f73d0aca340d8551f706056fab4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,73 @@
 {
   description = "A collection of templates for development projects";
 
-  outputs = { self }: {
-    templates = {
-      latex = {
-        path = ./latex;
-        description = "A LaTeX project";
-      };
-
-      python-poetry = {
-        path = ./python-poetry;
-        description = "A python project managed with Poetry";
-      };
-
-      python-mach-nix = {
-        path = ./python-mach-nix;
-        description = "A python project managed with mach-nix";
-      };
-
-      rust-cargo-integration = {
-        path = ./rust-cargo-integration;
-        description = "A Rust project managed by Cargo and integrated to Nix with nix-cargo-integration";
-      };
-    };
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    devshell.url = "github:numtide/devshell";
+    treefmt.url = "github:numtide/treefmt";
   };
+
+  outputs = { self, flake-utils, devshell, treefmt, nixpkgs }:
+    {
+      templates = {
+        latex = {
+          path = ./latex;
+          description = "A LaTeX project";
+        };
+
+        python-poetry = {
+          path = ./python-poetry;
+          description = "A python project managed with Poetry";
+        };
+
+        python-mach-nix = {
+          path = ./python-mach-nix;
+          description = "A python project managed with mach-nix";
+        };
+
+        rust-cargo-integration = {
+          path = ./rust-cargo-integration;
+          description =
+            "A Rust project managed by Cargo and integrated to Nix with nix-cargo-integration";
+        };
+      };
+    } //
+    # add basic devShell to pin CI workflows and
+    # to provide formatting utilities for all templates
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ devshell.overlay ];
+        };
+        fmt = pkgs.writeShellScriptBin "treefmt" ''
+          ${treefmt.defaultPackage.${system}}/bin/treefmt -q $@
+        '';
+      in
+      {
+        devShell = pkgs.devshell.mkShell {
+          packages = with pkgs; [
+            python3
+            nixpkgs-fmt
+            rustfmt
+            black
+          ];
+
+          commands = [
+            {
+              help = "Format the entire code tree";
+              name = "treefmt";
+              category = "utilities";
+              package = fmt;
+            }
+            {
+              help = "run checks on all flake outputs";
+              name = "checks";
+              category = "utilities";
+              command = "./checks";
+            }
+          ];
+        };
+      });
 }

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,13 @@
+# One CLI to format the code tree - https://github.com/numtide/treefmt
+
+[formatter.python]
+command = "black"
+includes = [ "*.py" ]
+
+[formatter.nix]
+command = "nixpkgs-fmt"
+includes = [ "*.nix" ]
+
+[formatter.rust]
+command = "rustfmt"
+includes = [ "*.rs" ]


### PR DESCRIPTION
adds a `devShell` output containing:

- `treefmt`, and corresponding dependencies for formatting tools in `treefmt.toml`
- `python3` to run CI checks
- updated `checks.yml` workflow to use these things and reject if anything fails (including formatting) because we have...standards?